### PR TITLE
Use correct package for Prometheus metrics link

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@
 
 - [moleculer-console-tracer](https://github.com/moleculerjs/moleculer-metrics/tree/master/packages/moleculer-console-tracer#readme) ![Official Moleculer Module][official] - Console-based service
 - [moleculer-jaeger](https://github.com/moleculerjs/moleculer-metrics/tree/master/packages/moleculer-jaeger#readme) ![Official Moleculer Module][official] - [Jaeger](https://www.jaegertracing.io/)-based metrics service
-- [moleculer-prometheus](https://github.com/moleculerjs/moleculer-metrics/tree/master/packages/moleculer-jaeger#readme) ![Official Moleculer Module][official] - [Prometheus](https://prometheus.io/)-based metrics service
+- [moleculer-prometheus](https://github.com/moleculerjs/moleculer-metrics/tree/master/packages/moleculer-prometheus#readme) ![Official Moleculer Module][official] - [Prometheus](https://prometheus.io/)-based metrics service
 - [moleculer-zipkin](https://github.com/moleculerjs/moleculer-metrics/tree/master/packages/moleculer-zipkin#readme) ![Official Moleculer Module][official] - [Zipkin](https://zipkin.io/)-based metrics service
 - [moleculer-elastic-apm](https://github.com/intech/moleculer-elastic-apm#moleculer-elastic-apm) - [Elastic APM](https://www.elastic.co/solutions/apm)-based metrics service
 - [moleculer-sentry](https://github.com/YourSoftRun/moleculer-sentry#readme) - [Sentry](https://sentry.io/)-based error logging


### PR DESCRIPTION
It was using the Jaeger package instead of the proper Prometheus one