### PR TITLE
Add moleculer-bullmq

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -529,6 +529,10 @@ mixins:
         desc: Task queue mixin for [AMQP](https://www.amqp.org/)
         official: false
         author: lehno
+      - name: moleculer-bullmq
+        link: https://github.com/Hugome/moleculer-bullmq#readme
+        desc: Task queue mixin for [BullMq](https://github.com/taskforcesh/bullmq)
+        author: Hugome
 
   validation:
     title: Validation


### PR DESCRIPTION
Add moleculer-bullmq

Add queue mixin for the new BullMq (https://docs.bullmq.io/)
It's an updated version of Bull (Same team)