### PR TITLE
Barebone moleculer services with gateway+service

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 - [StretchShop](https://github.com/Wradgio/StretchShop)  - Fast & scalable e-business REST API backend based on Moleculer framework, which makes it easy to run as monolithic or microservices application.
 - [Catalyst](https://github.com/derekbar90/catalyst)  - NodeJS Microservices Boilerplate - Typescript NodeJS Microservices Boilerplate with Generator CLI - Moleculer, GraphQL, REST, OAuth2, Jaeger, Grafana, Prometheus, Ory Hydra, Ory Keto w/ Access Control middleware, Moleculer-DB GraphQL mixin, Pug, Redis, sibling client repo (login, persistance layer, react-native-web, ios, android)
 - [Cards Against Formality](https://github.com/jordanpawlett/cards-against-formality-services)  - Cards Against Formality aims to be a web based clone of the popular card game "Cards against humanity". TypeScript + Kubernetes + Skaffold + authorization + scaled socket connections
+- [Barebone Moleculer App (A Gateway + Service](https://github.com/manjufy/moleculer-bare)
 ### Sandboxes on Codesandbox.io
 - [Simple project](https://codesandbox.io/s/github/moleculerjs/sandbox-moleculer-project)  - Moleculer + Moleculer Web + Greeter service
 - [API routing example](https://codesandbox.io/s/github/moleculerjs/sandbox-moleculer-api-routing)  - Moleculer + Moleculer Web + Routing examples

--- a/modules.yml
+++ b/modules.yml
@@ -138,6 +138,10 @@ examples:
       - name: Cards Against Formality
         link: https://github.com/jordanpawlett/cards-against-formality-services
         desc: Cards Against Formality aims to be a web based clone of the popular card game "Cards against humanity". TypeScript + Kubernetes + Skaffold + authorization + scaled socket connections
+      - name: moleculer-barebone
+        link: https://github.com/manjufy/moleculer-bare
+        desc: Barebone Moleculer With A Gateway and Service (Run without moleculer-runner)
+        author: Manjunath Reddy
 
   sandboxes:
     title: Sandboxes on Codesandbox.io


### PR DESCRIPTION
A Barebone moleculer with a Gateway and A service with Redis transporter.

I was following through the tutorial to create a barebone moleculer app based on the tutorial here https://moleculer.services/docs/0.14/concepts.html.
However, I noticed, using default NAT server would require us to download and configure locally. Since its way easy to install redis and use it as a Transporter.
In this repo, it demonstrate how to setup barebone moleculer services with a gateway and a service using Redis as transporter