### PR TITLE
chore: update moleculer-cron reference

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -598,10 +598,10 @@ mixins:
         official: false
         author: Hugome
       - name: moleculer-cron
-        link: https://github.com/davidroman0O/moleculer-cron#readme
-        desc: Cron mixin [Node-Cron](https://github.com/kelektiv/node-cron)
+        link: https://github.com/r2d2bzh/moleculer-cron#readme
+        desc: Moleculer mixin for [node-cron](https://github.com/kelektiv/node-cron)
         official: false
-        author: davidroman0O
+        author: furanzujin
       - name: moleculer-amqp-queue
         link: https://github.com/lehno/moleculer-amqp-queue#readme
         desc: Task queue mixin for [AMQP](https://www.amqp.org/)


### PR DESCRIPTION
Hi there,

It seems that [davidroman0O](https://github.com/davidroman0O) (maintainer of [moleculer-cron](https://github.com/davidroman0O/moleculer-cron)) is no longer active on Github for a couple of years now.
We encountered the same issue as described in [here](https://github.com/davidroman0O/moleculer-cron/pull/6) on `moleculer-cron` repository.
As we'd like to maintain it, we think the reference should be updated in `awesome-moleculer`.
