### PR TITLE
correct the repo url for the cron package

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -624,10 +624,15 @@ mixins:
         official: false
         author: Hugome
       - name: moleculer-cron
-        link: https://github.com/r2d2bzh/moleculer-cron#readme
+        link: 'https://github.com/davidroman0O/moleculer-cron#readme'
         desc: Moleculer mixin for [node-cron](https://github.com/kelektiv/node-cron)
         official: false
-        author: furanzujin
+        author: davidroman0O
+      - name: '@r2d2bzh/moleculer-cron'
+        link: 'https://github.com/r2d2bzh/moleculer-cron#readme'
+        desc: Another moleculer mixin for [node-cron](https://github.com/kelektiv/node-cron)
+        official: false
+        author: r2d2bzh
       - name: moleculer-amqp-queue
         link: https://github.com/lehno/moleculer-amqp-queue#readme
         desc: Task queue mixin for [AMQP](https://www.amqp.org/)

--- a/out/site_modules.yml
+++ b/out/site_modules.yml
@@ -440,7 +440,7 @@ tasks:
     author: Hugome
     display: unset
   - name: moleculer-cron
-    link: 'https://github.com/davidroman0O/moleculer-cron'
+    link: 'https://github.com/davidroman0O/moleculer-cron#readme'
     desc: |
       Moleculer mixin for <a href="https://github.com/kelektiv/node-cron">node-cron</a>
     official: false

--- a/out/site_modules.yml
+++ b/out/site_modules.yml
@@ -440,7 +440,7 @@ tasks:
     author: Hugome
     display: unset
   - name: moleculer-cron
-    link: 'https://github.com/r2d2bzh/moleculer-cron#readme'
+    link: 'https://github.com/davidroman0O/moleculer-cron'
     desc: |
       Moleculer mixin for <a href="https://github.com/kelektiv/node-cron">node-cron</a>
     official: false


### PR DESCRIPTION
The [NPM package](https://www.npmjs.com/package/moleculer-cron) come from this repository (and not the actual linked)
