### PR TITLE
Remove moleculer-zod-validator for the time being

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -662,11 +662,6 @@ mixins:
         desc: Use Typescript Intefraces as validator.
         official: false
         author: ipetrovic11
-      - name: moleculer-zod-validator
-        link: https://github.com/TheAppleFreak/moleculer-zod-validator
-        desc: A validator that allows the use of [Zod](https://github.com/colinhacks/zod) for type safe validation.
-        official: false
-        author: TheAppleFreak
 
   graphql:
     title: GraphQL


### PR DESCRIPTION
I feel quite embarrassed by this, but there was a fairly major bug in this module that slipped through my testing that I didn't realize until [after I had asked for the module's inclusion in this repository](https://github.com/moleculerjs/awesome-moleculer/pull/50). Given as this bug strongly impacts the intended use case of the function, I don't feel comfortable with it being here and publicized until that bug is fixed. Incredibly sorry about all this.