### PR TITLE
Add moleculer-zod-validator to Validators section again

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -667,6 +667,11 @@ mixins:
         desc: Use Typescript Intefraces as validator.
         official: false
         author: ipetrovic11
+      - name: moleculer-zod-validator
+        link: https://github.com/TheAppleFreak/moleculer-zod-validator
+        desc: A validator that allows the use of [Zod](https://github.com/colinhacks/zod) for type-safe validation and type inference.
+        official: false
+        author: TheAppleFreak
 
   graphql:
     title: GraphQL


### PR DESCRIPTION
After a bit of work, [I've got that bug that I mentioned a few days back squashed](https://github.com/moleculerjs/awesome-moleculer/pull/51) and everything should be working as expected now. Sorry again for the back and forth with all of this! 