### PR TITLE
add tiny-moleculer-py

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -791,6 +791,10 @@ polyglot:
       - name: moleculer-client
         link: https://github.com/CaioFilus/moleculer-client
         desc: Simple Client to communicate with Moleculer services using NATS.
+      - name: tiny-moleculer-py
+        link: https://github.com/tinnguyenhuuletrong/tiny-moleculer-py
+        desc: It is a lightweight asyncio python implementation of the Moleculer microservices framework support Redis Transport
+
 
   go:
     title: Go


### PR DESCRIPTION
Hi there!

I'd like to propose adding my new project, [tiny-moleculer-py](https://github.com/tinnguyenhuuletrong/tiny-moleculer-py), to the awesome-moleculer list.

It is a lightweight Python implementation of the Moleculer microservices framework, designed for a service need to working with Python.

Note

Currently it only support Redis transporter
Thanks,
[TTin]